### PR TITLE
add listen port argument on command line

### DIFF
--- a/bin/logcat
+++ b/bin/logcat
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
+var argv = process.argv.slice(2);
+
 var app = require('../app.js');
-app.listen(80);
+app.listen(parseInt(argv[0], 10) || 80);


### PR DESCRIPTION
Add listen port argument on command line.Then you can use `logcat 8080` to start logcat at port 8080,and needn't change the file.
